### PR TITLE
Add fish detection dashboard demo UI

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -1,0 +1,155 @@
+const stats = {
+  ytd: 12842,
+  mtd: 982,
+  wtd: 134,
+};
+
+const trendData = [
+  { day: 'Mon', value: 18 },
+  { day: 'Tue', value: 22 },
+  { day: 'Wed', value: 15 },
+  { day: 'Thu', value: 28 },
+  { day: 'Fri', value: 32 },
+  { day: 'Sat', value: 24 },
+  { day: 'Sun', value: 19 },
+];
+
+const lowConfidenceDetections = [
+  {
+    id: 'LC-2301',
+    species: 'Chinook Salmon',
+    confidence: 0.42,
+    detectedAt: '2024-03-28T07:23:00Z',
+    location: 'Station 12B',
+    imageUrl: 'https://images.unsplash.com/photo-1585128792020-803d29415281?auto=format&fit=crop&w=600&q=80',
+  },
+  {
+    id: 'LC-2294',
+    species: 'Steelhead Trout',
+    confidence: 0.37,
+    detectedAt: '2024-03-27T15:41:00Z',
+    location: 'Station 07A',
+    imageUrl: 'https://images.unsplash.com/photo-1508184964240-ee94ad12880e?auto=format&fit=crop&w=600&q=80',
+  },
+  {
+    id: 'LC-2289',
+    species: 'Sockeye Salmon',
+    confidence: 0.35,
+    detectedAt: '2024-03-27T04:18:00Z',
+    location: 'Station 04C',
+    imageUrl: 'https://images.unsplash.com/photo-1533090161767-e6ffed986c88?auto=format&fit=crop&w=600&q=80',
+  },
+];
+
+const state = {
+  detections: structuredClone(lowConfidenceDetections),
+};
+
+const formatNumber = (value) =>
+  new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
+
+const formatConfidence = (value) => `${Math.round(value * 100)}%`;
+
+const formatTimestamp = (isoString) =>
+  new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(isoString));
+
+const renderStats = () => {
+  document.getElementById('ytd-count').textContent = formatNumber(stats.ytd);
+  document.getElementById('mtd-count').textContent = formatNumber(stats.mtd);
+  document.getElementById('wtd-count').textContent = formatNumber(stats.wtd);
+};
+
+const renderTrend = () => {
+  const container = document.getElementById('trend-chart');
+  container.innerHTML = '';
+
+  const maxValue = Math.max(...trendData.map((entry) => entry.value));
+
+  trendData.forEach((entry) => {
+    const bar = document.createElement('div');
+    bar.className = 'trend-bar';
+
+    const valueLabel = document.createElement('span');
+    valueLabel.className = 'value';
+    valueLabel.textContent = entry.value;
+
+    const barShape = document.createElement('div');
+    barShape.className = 'bar';
+    barShape.style.height = `${(entry.value / maxValue) * 120}px`;
+
+    const dayLabel = document.createElement('span');
+    dayLabel.textContent = entry.day;
+
+    bar.append(valueLabel, barShape, dayLabel);
+    container.appendChild(bar);
+  });
+};
+
+const handleAccept = (id) => {
+  state.detections = state.detections.filter((detection) => detection.id !== id);
+  renderDetections();
+};
+
+const handleChangeSpecies = (id) => {
+  const detection = state.detections.find((item) => item.id === id);
+  if (!detection) return;
+
+  const newSpecies = prompt('Enter the correct species name:', detection.species);
+
+  if (newSpecies && newSpecies.trim().length > 0) {
+    detection.species = newSpecies.trim();
+    detection.confidence = 1;
+    renderDetections();
+  }
+};
+
+const renderDetections = () => {
+  const container = document.getElementById('review-container');
+  const template = document.getElementById('review-card-template');
+  container.innerHTML = '';
+
+  if (state.detections.length === 0) {
+    const emptyState = document.createElement('div');
+    emptyState.className = 'empty-state';
+    emptyState.innerHTML = `
+      <h3>All caught up! \uD83C\uDF89</h3>
+      <p>There are no low-confidence detections waiting for review.</p>
+    `;
+    container.appendChild(emptyState);
+    return;
+  }
+
+  state.detections.forEach((detection) => {
+    const card = template.content.firstElementChild.cloneNode(true);
+    const image = card.querySelector('.review-image');
+    const speciesName = card.querySelector('.species-name');
+    const confidence = card.querySelector('.confidence');
+    const timestamp = card.querySelector('.timestamp');
+    const location = card.querySelector('.location');
+    const acceptButton = card.querySelector('.action-button.accept');
+    const changeButton = card.querySelector('.action-button.change');
+
+    image.src = detection.imageUrl;
+    image.alt = `${detection.species} detection`;
+    speciesName.textContent = `${detection.species} (${detection.id})`;
+    confidence.textContent = formatConfidence(detection.confidence);
+    timestamp.textContent = formatTimestamp(detection.detectedAt);
+    location.textContent = detection.location;
+
+    acceptButton.addEventListener('click', () => handleAccept(detection.id));
+    changeButton.addEventListener('click', () => handleChangeSpecies(detection.id));
+
+    container.appendChild(card);
+  });
+};
+
+const init = () => {
+  renderStats();
+  renderTrend();
+  renderDetections();
+};
+
+document.addEventListener('DOMContentLoaded', init);

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ark.CV Fish Detection Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="top-bar">
+    <h1>Ark.CV Fish Detection Dashboard</h1>
+    <nav class="top-nav">
+      <a href="#overview" class="nav-link">Overview</a>
+      <a href="#review" class="nav-link">Review Detections</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="overview" class="card-grid">
+      <article class="stat-card">
+        <h2>Year-To-Date</h2>
+        <p class="stat-value" id="ytd-count">0</p>
+        <p class="stat-label">Fish counted</p>
+      </article>
+      <article class="stat-card">
+        <h2>Month-To-Date</h2>
+        <p class="stat-value" id="mtd-count">0</p>
+        <p class="stat-label">Fish counted</p>
+      </article>
+      <article class="stat-card">
+        <h2>Week-To-Date</h2>
+        <p class="stat-value" id="wtd-count">0</p>
+        <p class="stat-label">Fish counted</p>
+      </article>
+    </section>
+
+    <section id="trend" class="card">
+      <header class="card-header">
+        <h2>Daily Detection Trend (Last 7 Days)</h2>
+      </header>
+      <div class="trend-chart" id="trend-chart"></div>
+    </section>
+
+    <section id="review" class="card">
+      <header class="card-header">
+        <h2>Low Confidence Detections</h2>
+        <p>Review and resolve detections below the configured confidence threshold.</p>
+      </header>
+      <div class="review-grid" id="review-container">
+        <!-- Cards injected by JavaScript -->
+      </div>
+    </section>
+  </main>
+
+  <template id="review-card-template">
+    <article class="review-card">
+      <img class="review-image" alt="Fish detection" loading="lazy" />
+      <div class="review-body">
+        <h3 class="species-name"></h3>
+        <dl class="metadata">
+          <div>
+            <dt>Confidence</dt>
+            <dd class="confidence"></dd>
+          </div>
+          <div>
+            <dt>Detected</dt>
+            <dd class="timestamp"></dd>
+          </div>
+          <div>
+            <dt>Location</dt>
+            <dd class="location"></dd>
+          </div>
+        </dl>
+        <div class="action-group">
+          <button class="action-button accept">Accept Species</button>
+          <button class="action-button change">Change Species</button>
+        </div>
+      </div>
+    </article>
+  </template>
+
+  <footer class="footer">
+    <p>Ark.CV Demo Interface &bull; Built for model review workflows</p>
+  </footer>
+
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,0 +1,306 @@
+:root {
+  color-scheme: light dark;
+  --background: #0f172a;
+  --surface: #1e293b;
+  --surface-alt: #334155;
+  --accent: #38bdf8;
+  --accent-dark: #0ea5e9;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  --shadow: 0 20px 30px -20px rgba(15, 23, 42, 0.6);
+  font-family: 'Segoe UI', Roboto, system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1d4ed8 0%, rgba(30, 41, 59, 0.8) 40%, rgba(15, 23, 42, 0.95) 100%);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem clamp(1.5rem, 3vw, 3rem);
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--border);
+}
+
+.top-bar h1 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  letter-spacing: 0.02em;
+}
+
+.top-nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--text);
+}
+
+main {
+  flex: 1;
+  width: min(1100px, 95vw);
+  margin: 3rem auto;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.card,
+.stat-card {
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.9));
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.01em;
+}
+
+.stat-card h2 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.stat-value {
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  font-weight: 700;
+  margin: 0.25rem 0 0.5rem;
+  color: var(--accent);
+}
+
+.stat-label {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.trend-chart {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 1rem;
+  min-height: 180px;
+}
+
+.trend-bar {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.trend-bar .bar {
+  height: 100px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.8), rgba(14, 165, 233, 0.6));
+  position: relative;
+  overflow: hidden;
+}
+
+.trend-bar .bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.trend-bar .value {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.review-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 3rem 2rem;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 1.25rem;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  color: var(--text-muted);
+}
+
+.empty-state h3 {
+  margin-top: 0;
+  color: var(--text);
+}
+
+.review-card {
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, border 0.2s ease;
+}
+
+.review-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.review-image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.review-body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.species-name {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.metadata {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin: 0;
+}
+
+.metadata dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+}
+
+.metadata dd {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.action-group {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.action-button {
+  flex: 1;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.action-button:hover,
+.action-button:focus {
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-1px);
+}
+
+.action-button.accept {
+  background: rgba(56, 189, 248, 0.2);
+}
+
+.action-button.accept:hover,
+.action-button.accept:focus {
+  background: rgba(56, 189, 248, 0.35);
+}
+
+.action-button.change {
+  background: rgba(234, 179, 8, 0.2);
+}
+
+.action-button.change:hover,
+.action-button.change:focus {
+  background: rgba(234, 179, 8, 0.4);
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .top-nav {
+    width: 100%;
+  }
+
+  .nav-link {
+    display: inline-flex;
+    justify-content: center;
+    width: calc(50% - 0.5rem);
+    background: rgba(148, 163, 184, 0.12);
+  }
+
+  .metadata {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static fish detection dashboard with overview statistics and review workflow
- style the interface with responsive cards, trend visualization, and action buttons
- implement interactive logic to render dummy data and handle review actions

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68d71c64762083279274e2ec9d07003e